### PR TITLE
feat: allow custom time formatting in templates

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/charmbracelet/log"
@@ -251,6 +252,11 @@ var templatesFn template.FuncMap = template.FuncMap{
 	},
 	"urlencode": func(s string) string {
 		return url.QueryEscape(s)
+	},
+	"timeformat": func(format string, s string) string {
+		parsedTime, errParse := time.Parse("2006-01-02", s)
+		check(errParse)
+		return parsedTime.Format(format)
 	},
 }
 


### PR DESCRIPTION
Allows for a `timeformat` function in templates.

Example usage:

```
{{ .startdate | timeformat "January 2006" }}
```

I'm using this because the JSON Resume spec requires YYYY-MM-DD format in the JSON, but I'd prefer a more natural format in the HTML/PDF.

(PR from branch on my fork this time to avoid other changes)